### PR TITLE
updated justfile to fix air dep issue

### DIFF
--- a/justfile
+++ b/justfile
@@ -159,7 +159,7 @@ deps:
     {{go}} install mvdan.cc/gofumpt@latest
     {{go}} install golang.org/x/vuln/cmd/govulncheck@latest
     {{go}} install github.com/golang/mock/mockgen@latest
-    {{go}} install github.com/cosmtrek/air@latest
+    {{go}} install github.com/air-verse/air@latest
 
 # Update all project dependencies to their latest versions
 deps-update:


### PR DESCRIPTION
running `just init` throws:

```bash
go: github.com/cosmtrek/air@latest: version constraints conflict:
	github.com/cosmtrek/air@v1.61.1: parsing go.mod:
	module declares its path as: github.com/air-verse/air
	        but was required as: github.com/cosmtrek/air
```

I made a change on **_line 162_** in the **_justfile_** to correct it